### PR TITLE
Add jjwt api dependency for auth module

### DIFF
--- a/auth/pom.xml
+++ b/auth/pom.xml
@@ -62,6 +62,11 @@
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.12.6</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-impl</artifactId>
             <version>0.12.6</version>
             <scope>runtime</scope>


### PR DESCRIPTION
## Summary
- add the io.jsonwebtoken:jjwt-api dependency to the auth module pom so the JJWT classes resolve during compilation

## Testing
- mvn -f auth/pom.xml -q -DskipTests compile *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d487884d0c8327abe6bb424c507819