### PR TITLE
Fix validation stereotypes and tidy imports

### DIFF
--- a/auth/src/main/java/com/cryfirock/auth/service/config/AppConfig.java
+++ b/auth/src/main/java/com/cryfirock/auth/service/config/AppConfig.java
@@ -2,21 +2,21 @@ package com.cryfirock.auth.service.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.MessageSource;
 import org.springframework.context.support.ReloadableResourceBundleMessageSource;
 import org.springframework.lang.NonNull;
-import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.servlet.HandlerInterceptor;
 
 // Clase de configuración de Spring que además escanea paquetes
 @Configuration
 @ComponentScan(basePackages = {
         "com.cryfirock.auth.service",
-        "com.cryfirock.auth.service.validations"
+        "com.cryfirock.auth.service.validation"
 })
 public class AppConfig implements WebMvcConfigurer {
 

--- a/auth/src/main/java/com/cryfirock/auth/service/controller/UserController.java
+++ b/auth/src/main/java/com/cryfirock/auth/service/controller/UserController.java
@@ -1,8 +1,11 @@
 package com.cryfirock.auth.service.controller;
 
+import com.cryfirock.auth.service.entity.User;
+import com.cryfirock.auth.service.service.IUserService;
+import com.cryfirock.auth.service.util.ValidationUtils;
+import jakarta.validation.Valid;
 import java.util.List;
 import java.util.Optional;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,12 +20,6 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import com.cryfirock.auth.service.entity.User;
-import com.cryfirock.auth.service.service.IUserService;
-import com.cryfirock.auth.service.util.ValidationUtils;
-
-import jakarta.validation.Valid;
 
 /**
  * ==================================================================================================================
@@ -57,7 +54,7 @@ public class UserController {
     private IUserService userService;
 
     @Autowired
-    private ValidationUtils ValidationUtils;
+    private ValidationUtils validationUtils;
 
     /**
      * ==============================================================================================================
@@ -73,7 +70,7 @@ public class UserController {
     public ResponseEntity<?> createUser(@Valid @RequestBody User user, BindingResult result) {
         // Comprobar si hay errores en el envío de datos
         if (result.hasErrors())
-            return ValidationUtils
+            return validationUtils
                     // Devolver una respuesta con los errores
                     .reportIncorrectFields(result);
 
@@ -100,7 +97,7 @@ public class UserController {
     public ResponseEntity<?> createAdmin(@Valid @RequestBody User user, BindingResult result) {
         // Comprobar si hay errores en el envío de datos
         if (result.hasErrors())
-            return ValidationUtils
+            return validationUtils
                     // Devolver una respuesta con los errores
                     .reportIncorrectFields(result);
 
@@ -172,7 +169,7 @@ public class UserController {
         // Comprobar si hay errores en el envío de datos
         if (result.hasErrors())
             // Devolver una respuesta con los errores
-            return ValidationUtils
+            return validationUtils
                     .reportIncorrectFields(result);
 
         // Busca el usuario a actualizar

--- a/auth/src/main/java/com/cryfirock/auth/service/service/UserQueryServiceImpl.java
+++ b/auth/src/main/java/com/cryfirock/auth/service/service/UserQueryServiceImpl.java
@@ -2,12 +2,15 @@ package com.cryfirock.auth.service.service;
 
 import com.cryfirock.auth.service.repository.JpaUserRepository;
 
+import org.springframework.stereotype.Service;
+
 /**
  * =================================================================================
  * Paso 9.1: Servicio para comprobar existencia de datos de usuario
  * =================================================================================
  */
 
+@Service
 public class UserQueryServiceImpl implements IUserQueryService {
 
     /**

--- a/auth/src/main/java/com/cryfirock/auth/service/validation/ExistsByEmailValidationImpl.java
+++ b/auth/src/main/java/com/cryfirock/auth/service/validation/ExistsByEmailValidationImpl.java
@@ -1,11 +1,11 @@
 package com.cryfirock.auth.service.validation;
 
-import org.springframework.stereotype.Component;
-
 import com.cryfirock.auth.service.service.IUserQueryService;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
+
+import org.springframework.stereotype.Component;
 
 /**
  * ==============================================================================================

--- a/auth/src/main/java/com/cryfirock/auth/service/validation/ExistsByPhoneNumberValidationImpl.java
+++ b/auth/src/main/java/com/cryfirock/auth/service/validation/ExistsByPhoneNumberValidationImpl.java
@@ -5,11 +5,14 @@ import com.cryfirock.auth.service.service.IUserQueryService;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
+import org.springframework.stereotype.Component;
+
 /**
  * ==========================================================================================================
  * Paso 8.1: Clase validadora para phone number
  * ==========================================================================================================
  */
+@Component
 public class ExistsByPhoneNumberValidationImpl implements ConstraintValidator<IExistsByPhoneNumber, String> {
 
     /**

--- a/auth/src/main/java/com/cryfirock/auth/service/validation/ExistsByUsernameValidationImpl.java
+++ b/auth/src/main/java/com/cryfirock/auth/service/validation/ExistsByUsernameValidationImpl.java
@@ -5,11 +5,14 @@ import com.cryfirock.auth.service.service.IUserQueryService;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
+import org.springframework.stereotype.Component;
+
 /**
  * ==============================================================================================
  * Paso 8.1: Clase validadora para username
  * ==============================================================================================
  */
+@Component
 public class ExistsByUsernameValidationImpl implements ConstraintValidator<IExistsByUsername, String> {
 
     /**


### PR DESCRIPTION
## Summary
- register missing Spring stereotypes for validation and query services and fix the component scan package
- normalize import ordering and correct the ValidationUtils injection name in the user controller

## Testing
- `sh mvnw test` *(fails: existing SpringBootTest cannot locate a @SpringBootConfiguration)*

------
https://chatgpt.com/codex/tasks/task_e_68e65cb0c1fc83279c51ac9c78e5725f