### PR TITLE
Add product catalog modeling and account-product association

### DIFF
--- a/product/src/main/java/com/cryfirock/product/entity/AccountProduct.java
+++ b/product/src/main/java/com/cryfirock/product/entity/AccountProduct.java
@@ -1,0 +1,71 @@
+package com.cryfirock.product.entity;
+
+import java.time.LocalDateTime;
+
+import com.cryfirock.product.type.AccountProductStatus;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 1. Clase que representa la relación entre una cuenta y un producto contratado.
+ * 2. Permite gestionar múltiples productos activos por cuenta según reglas del catálogo.
+ * 3. Almacena el estado y fechas relevantes del producto en la cuenta.
+ *
+ * @author Cristo Suárez
+ * @version 1.0
+ * @since 2025-01-21
+ * @see <a href="https://cristo.vercel.app">cristo.vercel.app</a>
+ */
+@Entity
+@Table(name = "account_product")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AccountProduct {
+    // Identificador único de la relación cuenta-producto.
+    // Ejemplo: 5001.
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // Identificador de la cuenta propietaria del producto.
+    // Ejemplo: 1001.
+    @Column(name = "account_id", nullable = false)
+    private Long accountId;
+
+    // Producto asociado a la cuenta.
+    @ManyToOne
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    // Estado actual del producto dentro de la cuenta.
+    // Ejemplo: ACTIVE.
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private AccountProductStatus status;
+
+    // Fecha y hora de activación del producto en la cuenta.
+    // Ejemplo: 2025-01-21T10:15:30.
+    @Column(name = "activated_at")
+    private LocalDateTime activatedAt;
+
+    // Fecha y hora de cierre del producto en la cuenta.
+    // Ejemplo: 2025-06-30T18:00:00.
+    @Column(name = "closed_at")
+    private LocalDateTime closedAt;
+}
+

--- a/product/src/main/java/com/cryfirock/product/entity/Product.java
+++ b/product/src/main/java/com/cryfirock/product/entity/Product.java
@@ -1,9 +1,25 @@
 package com.cryfirock.product.entity;
 
+import com.cryfirock.product.type.ProductCategory;
+import com.cryfirock.product.type.ProductStatus;
+
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
- * Clase que representa los diferentes tipos de productos financieros ofrecidos por la plataforma.
+ * 1. Clase que representa el catálogo de productos financieros de la plataforma.
+ * 2. Define reglas de disponibilidad y límites por cuenta.
+ * 3. Centraliza metadatos comunes para cualquier familia de producto.
  *
  * @author Cristo Suárez
  * @version 1.0
@@ -11,5 +27,58 @@ import jakarta.persistence.Entity;
  * @see <a href="https://cristo.vercel.app">cristo.vercel.app</a>
  */
 @Entity
+@Table(name = "product")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class Product {
+    // Identificador único del producto en la base de datos.
+    // Ejemplo: 1001.
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // Código interno para identificar el producto de forma única.
+    // Ejemplo: ACC_CHECKING.
+    @Column(name = "code", nullable = false, unique = true, length = 64)
+    private String code;
+
+    // Nombre comercial del producto.
+    // Ejemplo: Cuenta Corriente.
+    @Column(name = "name", nullable = false, length = 120)
+    private String name;
+
+    // Descripción funcional del producto.
+    // Ejemplo: Cuenta bancaria para operaciones diarias.
+    @Column(name = "description", length = 500)
+    private String description;
+
+    // Familia principal del producto.
+    // Ejemplo: ACCOUNT.
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false, length = 40)
+    private ProductCategory category;
+
+    // Subtipo específico dentro de la familia del producto.
+    // Ejemplo: CHECKING.
+    @Column(name = "sub_type", nullable = false, length = 60)
+    private String subType;
+
+    // Número máximo de productos activos por cuenta para este subtipo.
+    // Ejemplo: 1.
+    @Column(name = "max_active_per_account", nullable = false)
+    private Integer maxActivePerAccount;
+
+    // Indica si la cuenta puede tener más de un producto activo del mismo subtipo.
+    // Ejemplo: false.
+    @Column(name = "allows_multiple", nullable = false)
+    private Boolean allowsMultiple;
+
+    // Estado de disponibilidad del producto en la plataforma.
+    // Ejemplo: ACTIVE.
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private ProductStatus status;
 }
+

--- a/product/src/main/java/com/cryfirock/product/type/AccountProductStatus.java
+++ b/product/src/main/java/com/cryfirock/product/type/AccountProductStatus.java
@@ -1,0 +1,16 @@
+package com.cryfirock.product.type;
+
+/**
+ * Enum que representa el estado de un producto asociado a una cuenta.
+ *
+ * @author Cristo Suárez
+ * @version 1.0
+ * @since 2025-01-21
+ * @see <a href="https://cristo.vercel.app">cristo.vercel.app</a>
+ */
+public enum AccountProductStatus {
+    ACTIVE,    // Producto activo en la cuenta.
+    SUSPENDED, // Producto suspendido temporalmente.
+    CLOSED     // Producto cerrado o inactivo definitivamente.
+}
+

--- a/product/src/main/java/com/cryfirock/product/type/ProductCategory.java
+++ b/product/src/main/java/com/cryfirock/product/type/ProductCategory.java
@@ -1,0 +1,21 @@
+package com.cryfirock.product.type;
+
+/**
+ * Enum que representa las familias principales de productos disponibles.
+ *
+ * @author Cristo Suárez
+ * @version 1.0
+ * @since 2025-01-21
+ * @see <a href="https://cristo.vercel.app">cristo.vercel.app</a>
+ */
+public enum ProductCategory {
+    ACCOUNT,     // Productos de cuenta bancaria.
+    CARD,        // Productos de tarjetas.
+    CREDIT,      // Productos de crédito.
+    CRYPTO,      // Productos de criptomonedas.
+    DERIVATIVES, // Productos de trading con derivados.
+    FINANCING,   // Productos de financiación.
+    INVESTMENT,  // Productos de inversión tradicional.
+    LOYALTY      // Productos de fidelización.
+}
+

--- a/product/src/main/java/com/cryfirock/product/type/ProductStatus.java
+++ b/product/src/main/java/com/cryfirock/product/type/ProductStatus.java
@@ -1,0 +1,16 @@
+package com.cryfirock.product.type;
+
+/**
+ * Enum que representa los estados de disponibilidad de un producto.
+ *
+ * @author Cristo Suárez
+ * @version 1.0
+ * @since 2025-01-21
+ * @see <a href="https://cristo.vercel.app">cristo.vercel.app</a>
+ */
+public enum ProductStatus {
+    ACTIVE,   // Producto disponible para su contratación.
+    INACTIVE, // Producto no disponible temporalmente.
+    CLOSED   // Producto retirado del catálogo.
+}
+


### PR DESCRIPTION
### Motivation
- Model a product catalog with metadata, availability rules and per-account limits for financial products.
- Represent relationships between accounts and contracted products including lifecycle timestamps and per-account status.
- Centralize product domain enums for category and availability states to ensure consistent typing across the module.

### Description
- Add `Product` JPA entity with fields `id`, `code`, `name`, `description`, `category`, `subType`, `maxActivePerAccount`, `allowsMultiple` and `status`, plus Lombok annotations and `@Table(name = "product")` mapping.
- Add `AccountProduct` JPA entity linking an `accountId` to a `Product` with fields `id`, `product`, `status`, `activatedAt` and `closedAt`, using `@ManyToOne` and Lombok annotations.
- Introduce enums `ProductCategory`, `ProductStatus` and `AccountProductStatus` to enumerate product families and lifecycle states.
- Apply JPA column constraints (nullable, lengths, unique) and use `@Enumerated(EnumType.STRING)` for enum persistence.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697218ab427c8327ab01d1d5ed46c186)