### PR TITLE
Agregar CRUD de Account con relaciones a Usuarios y Productos

### DIFF
--- a/account/src/main/java/com/cryfirock/account/controller/AccountController.java
+++ b/account/src/main/java/com/cryfirock/account/controller/AccountController.java
@@ -1,0 +1,103 @@
+package com.cryfirock.account.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.cryfirock.account.dto.AccountRequestDto;
+import com.cryfirock.account.dto.AccountResponseDto;
+import com.cryfirock.account.service.api.IAccountService;
+
+/**
+ * 1. Controlador REST para operaciones CRUD de cuentas.
+ * 2. Expone endpoints para consultar relaciones con usuarios y productos.
+ *
+ * @author Cristo Suárez
+ * @version 1.0
+ * @since 2026-01-24
+ */
+@RestController
+@RequestMapping("/api/accounts")
+public class AccountController {
+    // Servicio para operaciones de cuentas.
+    private final IAccountService accountService;
+
+    /**
+     * Constructor que inyecta el servicio de cuentas.
+     *
+     * @param accountService Servicio de cuentas.
+     */
+    public AccountController(IAccountService accountService) {
+        this.accountService = accountService;
+    }
+
+    /**
+     * 1. Crea una cuenta con usuarios y productos asociados.
+     *
+     * @param request Datos de la cuenta y relaciones.
+     * @return Cuenta creada con relaciones.
+     */
+    @PostMapping
+    public ResponseEntity<AccountResponseDto> create(@RequestBody AccountRequestDto request) {
+        return ResponseEntity.ok(accountService.create(request));
+    }
+
+    /**
+     * 1. Actualiza una cuenta y sus relaciones asociadas.
+     *
+     * @param id Identificador de la cuenta.
+     * @param request Datos actualizados de la cuenta y relaciones.
+     * @return Cuenta actualizada con relaciones.
+     */
+    @PutMapping("/{id}")
+    public ResponseEntity<AccountResponseDto> update(
+            @PathVariable Long id,
+            @RequestBody AccountRequestDto request
+    ) {
+        return ResponseEntity.ok(accountService.update(id, request));
+    }
+
+    /**
+     * 1. Obtiene una cuenta con usuarios y productos asociados.
+     *
+     * @param id Identificador de la cuenta.
+     * @return Cuenta con relaciones.
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<AccountResponseDto> findById(@PathVariable Long id) {
+        return ResponseEntity.ok(accountService.findById(id));
+    }
+
+    /**
+     * 1. Obtiene cuentas asociadas a un usuario.
+     * 2. Incluye productos asociados a cada cuenta.
+     *
+     * @param userId Identificador del usuario.
+     * @return Lista de cuentas con relaciones.
+     */
+    @GetMapping("/users/{userId}")
+    public ResponseEntity<List<AccountResponseDto>> findByUserId(@PathVariable Long userId) {
+        return ResponseEntity.ok(accountService.findByUserId(userId));
+    }
+
+    /**
+     * 1. Elimina una cuenta y sus relaciones.
+     *
+     * @param id Identificador de la cuenta.
+     * @return Respuesta sin contenido.
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        accountService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}
+

--- a/account/src/main/java/com/cryfirock/account/dto/AccountRequestDto.java
+++ b/account/src/main/java/com/cryfirock/account/dto/AccountRequestDto.java
@@ -1,0 +1,32 @@
+package com.cryfirock.account.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import com.cryfirock.account.type.AccountAssets;
+import com.cryfirock.account.type.AccountNature;
+import com.cryfirock.account.type.AccountOperational;
+import com.cryfirock.account.type.AccountStatus;
+
+/**
+ * 1. DTO para crear o actualizar una cuenta con relaciones.
+ * 2. Incluye usuarios y productos a asociar en el microservicio account.
+ *
+ * @author Cristo Suárez
+ * @version 1.0
+ * @since 2026-01-24
+ */
+public record AccountRequestDto(
+        Long ownerId,
+        AccountAssets asset,
+        String currency,
+        String number,
+        BigDecimal balance,
+        AccountNature nature,
+        AccountOperational operational,
+        AccountStatus status,
+        List<Long> userIds,
+        List<Long> productIds
+) {
+}
+

--- a/account/src/main/java/com/cryfirock/account/dto/AccountResponseDto.java
+++ b/account/src/main/java/com/cryfirock/account/dto/AccountResponseDto.java
@@ -1,0 +1,35 @@
+package com.cryfirock.account.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import com.cryfirock.account.entity.Audit;
+import com.cryfirock.account.type.AccountAssets;
+import com.cryfirock.account.type.AccountNature;
+import com.cryfirock.account.type.AccountOperational;
+import com.cryfirock.account.type.AccountStatus;
+
+/**
+ * 1. DTO de respuesta para exponer una cuenta con relaciones.
+ * 2. Incluye los identificadores de usuarios y productos asociados.
+ *
+ * @author Cristo Suárez
+ * @version 1.0
+ * @since 2026-01-24
+ */
+public record AccountResponseDto(
+        Long id,
+        Long ownerId,
+        AccountAssets asset,
+        String currency,
+        String number,
+        BigDecimal balance,
+        AccountNature nature,
+        AccountOperational operational,
+        AccountStatus status,
+        Audit audit,
+        List<Long> userIds,
+        List<Long> productIds
+) {
+}
+

--- a/account/src/main/java/com/cryfirock/account/entity/AccountProduct.java
+++ b/account/src/main/java/com/cryfirock/account/entity/AccountProduct.java
@@ -1,0 +1,49 @@
+package com.cryfirock.account.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 1. Entidad que relaciona cuentas con productos.
+ * 2. Guarda el identificador del producto del microservicio product.
+ * 3. Representa la relación muchos a muchos entre cuentas y productos.
+ *
+ * @author Cristo Suárez
+ * @version 1.0
+ * @since 2026-01-24
+ */
+@Entity
+@Table(
+        name = "account_product",
+        uniqueConstraints = {
+            @UniqueConstraint(columnNames = { "account_id", "product_id" })
+        }
+)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AccountProduct {
+    // Identificador único del registro de relación.
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // Identificador de la cuenta asociada.
+    @Column(name = "account_id", nullable = false)
+    private Long accountId;
+
+    // Identificador del producto asociado.
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
+}
+

--- a/account/src/main/java/com/cryfirock/account/entity/AccountUser.java
+++ b/account/src/main/java/com/cryfirock/account/entity/AccountUser.java
@@ -1,0 +1,49 @@
+package com.cryfirock.account.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 1. Entidad que relaciona cuentas con usuarios.
+ * 2. Guarda el identificador del usuario del microservicio auth.
+ * 3. Representa la relación muchos a muchos entre cuentas y usuarios.
+ *
+ * @author Cristo Suárez
+ * @version 1.0
+ * @since 2026-01-24
+ */
+@Entity
+@Table(
+        name = "account_user",
+        uniqueConstraints = {
+            @UniqueConstraint(columnNames = { "account_id", "user_id" })
+        }
+)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AccountUser {
+    // Identificador único del registro de relación.
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // Identificador de la cuenta asociada.
+    @Column(name = "account_id", nullable = false)
+    private Long accountId;
+
+    // Identificador del usuario asociado.
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+}
+

--- a/account/src/main/java/com/cryfirock/account/repository/JpaAccountProductRepository.java
+++ b/account/src/main/java/com/cryfirock/account/repository/JpaAccountProductRepository.java
@@ -1,0 +1,33 @@
+package com.cryfirock.account.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.cryfirock.account.entity.AccountProduct;
+
+/**
+ * 1. Repositorio JPA para relaciones de cuentas con productos.
+ * 2. Permite operaciones CRUD sobre la tabla account_product.
+ * 3. Expone consultas básicas por Spring Data.
+ *
+ * @author Cristo Suárez
+ * @version 1.0
+ * @since 2026-01-24
+ */
+public interface JpaAccountProductRepository extends JpaRepository<AccountProduct, Long> {
+    /**
+     * 1. Obtiene las relaciones de producto por identificador de cuenta.
+     * 2. Permite recuperar productos asociados a una cuenta.
+     *
+     * @param accountId Identificador de la cuenta.
+     * @return Lista de relaciones cuenta producto.
+     */
+    java.util.List<AccountProduct> findAllByAccountId(Long accountId);
+
+    /**
+     * 1. Elimina las relaciones de producto asociadas a una cuenta.
+     * 2. Se usa para reemplazar relaciones en actualizaciones.
+     *
+     * @param accountId Identificador de la cuenta.
+     */
+    void deleteAllByAccountId(Long accountId);
+}

--- a/account/src/main/java/com/cryfirock/account/repository/JpaAccountRepository.java
+++ b/account/src/main/java/com/cryfirock/account/repository/JpaAccountRepository.java
@@ -1,0 +1,18 @@
+package com.cryfirock.account.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.cryfirock.account.entity.Account;
+
+/**
+ * 1. Repositorio JPA para la entidad Account.
+ * 2. Permite operaciones CRUD sobre la tabla account.
+ * 3. Expone consultas básicas por Spring Data.
+ *
+ * @author Cristo Suárez
+ * @version 1.0
+ * @since 2026-01-24
+ */
+public interface JpaAccountRepository extends JpaRepository<Account, Long> {
+}
+

--- a/account/src/main/java/com/cryfirock/account/repository/JpaAccountUserRepository.java
+++ b/account/src/main/java/com/cryfirock/account/repository/JpaAccountUserRepository.java
@@ -1,0 +1,42 @@
+package com.cryfirock.account.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.cryfirock.account.entity.AccountUser;
+
+/**
+ * 1. Repositorio JPA para relaciones de cuentas con usuarios.
+ * 2. Permite operaciones CRUD sobre la tabla account_user.
+ * 3. Expone consultas básicas por Spring Data.
+ *
+ * @author Cristo Suárez
+ * @version 1.0
+ * @since 2026-01-24
+ */
+public interface JpaAccountUserRepository extends JpaRepository<AccountUser, Long> {
+    /**
+     * 1. Obtiene las relaciones de cuenta por identificador de usuario.
+     * 2. Permite recuperar cuentas asociadas a un usuario específico.
+     *
+     * @param userId Identificador del usuario en auth.
+     * @return Lista de relaciones cuenta usuario.
+     */
+    java.util.List<AccountUser> findAllByUserId(Long userId);
+
+    /**
+     * 1. Obtiene las relaciones de usuario por identificador de cuenta.
+     * 2. Permite recuperar usuarios asociados a una cuenta.
+     *
+     * @param accountId Identificador de la cuenta.
+     * @return Lista de relaciones cuenta usuario.
+     */
+    java.util.List<AccountUser> findAllByAccountId(Long accountId);
+
+    /**
+     * 1. Elimina las relaciones de usuario asociadas a una cuenta.
+     * 2. Se usa para reemplazar relaciones en actualizaciones.
+     *
+     * @param accountId Identificador de la cuenta.
+     */
+    void deleteAllByAccountId(Long accountId);
+}

--- a/account/src/main/java/com/cryfirock/account/service/api/IAccountService.java
+++ b/account/src/main/java/com/cryfirock/account/service/api/IAccountService.java
@@ -1,0 +1,59 @@
+package com.cryfirock.account.service.api;
+
+import java.util.List;
+
+import com.cryfirock.account.dto.AccountRequestDto;
+import com.cryfirock.account.dto.AccountResponseDto;
+
+/**
+ * 1. Contrato para operaciones CRUD de cuentas y relaciones asociadas.
+ * 2. Expone consultas por usuario para recuperar cuentas vinculadas.
+ *
+ * @author Cristo Suárez
+ * @version 1.0
+ * @since 2026-01-24
+ */
+public interface IAccountService {
+    /**
+     * 1. Crea una cuenta junto con sus relaciones de usuarios y productos.
+     *
+     * @param request Datos de la cuenta y relaciones.
+     * @return Cuenta creada con relaciones.
+     */
+    AccountResponseDto create(AccountRequestDto request);
+
+    /**
+     * 1. Actualiza una cuenta y reemplaza sus relaciones.
+     *
+     * @param id Identificador de la cuenta.
+     * @param request Datos actualizados de la cuenta y relaciones.
+     * @return Cuenta actualizada con relaciones.
+     */
+    AccountResponseDto update(Long id, AccountRequestDto request);
+
+    /**
+     * 1. Obtiene una cuenta por identificador.
+     * 2. Incluye usuarios y productos asociados.
+     *
+     * @param id Identificador de la cuenta.
+     * @return Cuenta con relaciones.
+     */
+    AccountResponseDto findById(Long id);
+
+    /**
+     * 1. Obtiene las cuentas asociadas a un usuario.
+     * 2. Incluye los productos asociados a cada cuenta.
+     *
+     * @param userId Identificador del usuario.
+     * @return Lista de cuentas con relaciones.
+     */
+    List<AccountResponseDto> findByUserId(Long userId);
+
+    /**
+     * 1. Elimina una cuenta y sus relaciones.
+     *
+     * @param id Identificador de la cuenta.
+     */
+    void delete(Long id);
+}
+

--- a/account/src/main/java/com/cryfirock/account/service/impl/AccountServiceImpl.java
+++ b/account/src/main/java/com/cryfirock/account/service/impl/AccountServiceImpl.java
@@ -1,0 +1,182 @@
+package com.cryfirock.account.service.impl;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.cryfirock.account.dto.AccountRequestDto;
+import com.cryfirock.account.dto.AccountResponseDto;
+import com.cryfirock.account.entity.Account;
+import com.cryfirock.account.entity.AccountProduct;
+import com.cryfirock.account.entity.AccountUser;
+import com.cryfirock.account.repository.JpaAccountProductRepository;
+import com.cryfirock.account.repository.JpaAccountRepository;
+import com.cryfirock.account.repository.JpaAccountUserRepository;
+import com.cryfirock.account.service.api.IAccountService;
+
+/**
+ * 1. Implementación del servicio para gestionar cuentas y relaciones.
+ * 2. Orquesta la persistencia de cuentas con usuarios y productos asociados.
+ *
+ * @author Cristo Suárez
+ * @version 1.0
+ * @since 2026-01-24
+ */
+@Service
+public class AccountServiceImpl implements IAccountService {
+    // Repositorio de cuentas.
+    private final JpaAccountRepository accountRepository;
+
+    // Repositorio de relaciones cuenta usuario.
+    private final JpaAccountUserRepository accountUserRepository;
+
+    // Repositorio de relaciones cuenta producto.
+    private final JpaAccountProductRepository accountProductRepository;
+
+    /**
+     * Constructor que inyecta dependencias del servicio.
+     *
+     * @param accountRepository Repositorio de cuentas.
+     * @param accountUserRepository Repositorio de relaciones cuenta usuario.
+     * @param accountProductRepository Repositorio de relaciones cuenta producto.
+     */
+    public AccountServiceImpl(
+            JpaAccountRepository accountRepository,
+            JpaAccountUserRepository accountUserRepository,
+            JpaAccountProductRepository accountProductRepository
+    ) {
+        this.accountRepository = accountRepository;
+        this.accountUserRepository = accountUserRepository;
+        this.accountProductRepository = accountProductRepository;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Transactional
+    public AccountResponseDto create(AccountRequestDto request) {
+        Account account = new Account();
+        applyRequest(account, request);
+        Account savedAccount = accountRepository.save(account);
+        saveRelations(savedAccount.getId(), request.userIds(), request.productIds());
+        return buildResponse(savedAccount);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Transactional
+    public AccountResponseDto update(Long id, AccountRequestDto request) {
+        Account account = accountRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+        applyRequest(account, request);
+        Account savedAccount = accountRepository.save(account);
+        accountUserRepository.deleteAllByAccountId(savedAccount.getId());
+        accountProductRepository.deleteAllByAccountId(savedAccount.getId());
+        saveRelations(savedAccount.getId(), request.userIds(), request.productIds());
+        return buildResponse(savedAccount);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public AccountResponseDto findById(Long id) {
+        Account account = accountRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+        return buildResponse(account);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public List<AccountResponseDto> findByUserId(Long userId) {
+        List<Long> accountIds = accountUserRepository.findAllByUserId(userId).stream()
+                .map(AccountUser::getAccountId)
+                .distinct()
+                .toList();
+        return accountRepository.findAllById(accountIds).stream()
+                .map(this::buildResponse)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Transactional
+    public void delete(Long id) {
+        accountUserRepository.deleteAllByAccountId(id);
+        accountProductRepository.deleteAllByAccountId(id);
+        accountRepository.deleteById(id);
+    }
+
+    private void applyRequest(Account account, AccountRequestDto request) {
+        account.setOwnerId(request.ownerId());
+        account.setAsset(request.asset());
+        account.setCurrency(request.currency());
+        account.setNumber(request.number());
+        account.setBalance(request.balance());
+        account.setNature(request.nature());
+        account.setOperational(request.operational());
+        account.setStatus(request.status());
+    }
+
+    private void saveRelations(Long accountId, List<Long> userIds, List<Long> productIds) {
+        List<AccountUser> accountUsers = safeList(userIds).stream()
+                .filter(Objects::nonNull)
+                .map(userId -> new AccountUser(null, accountId, userId))
+                .toList();
+        List<AccountProduct> accountProducts = safeList(productIds).stream()
+                .filter(Objects::nonNull)
+                .map(productId -> new AccountProduct(null, accountId, productId))
+                .toList();
+        if (!accountUsers.isEmpty()) {
+            accountUserRepository.saveAll(accountUsers);
+        }
+        if (!accountProducts.isEmpty()) {
+            accountProductRepository.saveAll(accountProducts);
+        }
+    }
+
+    private List<Long> safeList(List<Long> values) {
+        return values == null ? List.of() : values;
+    }
+
+    private AccountResponseDto buildResponse(Account account) {
+        List<Long> userIds = accountUserRepository.findAllByAccountId(account.getId()).stream()
+                .map(AccountUser::getUserId)
+                .distinct()
+                .toList();
+        List<Long> productIds = accountProductRepository
+                .findAllByAccountId(account.getId())
+                .stream()
+                .map(AccountProduct::getProductId)
+                .distinct()
+                .toList();
+        return new AccountResponseDto(
+                account.getId(),
+                account.getOwnerId(),
+                account.getAsset(),
+                account.getCurrency(),
+                account.getNumber(),
+                account.getBalance(),
+                account.getNature(),
+                account.getOperational(),
+                account.getStatus(),
+                account.getAudit(),
+                userIds,
+                productIds
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- Modelar las relaciones muchos-a-muchos entre `Account` y entidades externas `User` y `Product` para que el servicio `account` pueda persistir y exponer asociaciones.
- Permitir crear, actualizar y eliminar cuentas junto con sus relaciones, y devolver los identificadores de usuarios y productos asociados al consultar una cuenta.
- Proveer un endpoint para recuperar las cuentas asociadas a un `userId` incluyendo los `productIds` de cada cuenta.

### Description
- Añade las entidades `AccountUser` y `AccountProduct` con `@UniqueConstraint` sobre `(account_id, user_id)` y `(account_id, product_id)` para evitar duplicados en la BD.
- Introduce los repositorios `JpaAccountUserRepository`, `JpaAccountProductRepository` y `JpaAccountRepository` con consultas `findAllByUserId`, `findAllByAccountId` y `deleteAllByAccountId` para mantener y consultar relaciones.
- Añade los DTOs `AccountRequestDto` y `AccountResponseDto` que incluyen listas de `userIds` y `productIds` para crear/mostrar cuentas con sus asociaciones.
- Implementa el contrato `IAccountService`, la clase `AccountServiceImpl` que orquesta creación/actualización/eliminación de cuentas y relaciones (reemplaza relaciones existentes al actualizar), y el controlador `AccountController` con endpoints CRUD bajo `/api/accounts` y `/api/accounts/users/{userId}`.

### Testing
- No se ejecutaron pruebas automatizadas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69753408f28083279250c78e6e148621)