### PR TITLE
Refactor comentarios y mensajes de validación null-safe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,6 +269,10 @@ com.cryfirock.auth/
 
 Los errores deben ser capturados y transformados en respuestas HTTP adecuadas utilizando `@RestControllerAdvice`.
 
+### Validaciones y mensajes nulos
+
+- Cuando uses `FieldError#getDefaultMessage`, define un fallback no nulo para el mensaje.
+
 ### Flujo de Captura de Errores
 
 | Escenario | Causa | Flujo de Excepción | Respuesta HTTP |

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - [Módulo Accounts](#-módulo-accounts) ⭍
 - [Módulo OAuth2](#-módulo-oauth2) ⭍
 - [Módulo Product](#-módulo-product) ⭍
+- [Validaciones y mensajes](#-validaciones-y-mensajes) ⭍
 - [Ejecución de Módulos](#-ejecución-de-módulos) ⭍
 - [API Endpoints](#-api-endpoints) ⭍
 
@@ -27,6 +28,10 @@
 ### 🔐 MÓDULO AUTH
 
 > Microservicio de Autenticación y Gestión de Usuarios
+
+### ✅ VALIDACIONES Y MENSAJES
+
+> Las utilidades de validación devuelven mensajes no nulos en respuestas de error.
 
 ### ⚙️ Configuración Principal
 

--- a/account/src/main/java/com/cryfirock/account/entity/AccountUser.java
+++ b/account/src/main/java/com/cryfirock/account/entity/AccountUser.java
@@ -25,8 +25,7 @@ import lombok.Setter;
 @Entity @Table(
         // Tabla que relaciona cuentas bancarias con usuarios.
         name = "account_user",
-        // 1. Restricción única que asegura que una cuenta bancaria solo pueda tener un
-        // usuario.
+        // 1. Restricción única para evitar duplicados de cuenta y usuario.
         // 2. Ejemplo: Una cuenta bancaria no puede tener dos usuarios.
         uniqueConstraints = {
                 @UniqueConstraint(columnNames = { "account_id", "user_id" })

--- a/account/src/main/java/com/cryfirock/account/service/impl/AccountServiceImpl.java
+++ b/account/src/main/java/com/cryfirock/account/service/impl/AccountServiceImpl.java
@@ -94,8 +94,7 @@ public class AccountServiceImpl implements IAccountService {
                 .findById(id)
                 // Si no se encuentra la cuenta lanza una excepción.
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
-        // Aplica los datos del request a la cuenta (solo los datos que se van a
-        // actualizar).
+        // Aplica a la cuenta solo los datos del request que se van a actualizar.
         applyRequest(account, request);
 
         // Almacena la cuenta en la base de datos y retorna la cuenta con el id.

--- a/auth/src/main/java/com/cryfirock/auth/controller/UserController.java
+++ b/auth/src/main/java/com/cryfirock/auth/controller/UserController.java
@@ -62,8 +62,7 @@ public class UserController {
         return (result.hasErrors())
                 // 1. Verifica si hay errores de validación.
                 // 2. Si hay errores reporta los campos incorrectos.
-                // 3. Si no hay errores guarda el usuario y retorna un estado
-                // CREATED.
+                // 3. Si no hay errores guarda el usuario y retorna un estado CREATED.
                 ? ValidationUtil.reportIncorrectFields(result)
                 : ResponseEntity.status(HttpStatus.CREATED)
                         .body(userService.save(user));
@@ -183,11 +182,9 @@ public class UserController {
         return userService
                 // Intenta eliminar el usuario por ID.
                 .deleteById(id)
-                // Si se elimina devuelve un ResponseEntity con estado 204 No
-                // Content en JSON.
+                // Si se elimina devuelve un ResponseEntity con estado 204 No Content en JSON.
                 .map(user -> ResponseEntity.noContent().build())
-                // Si no existe devuelve un ResponseEntity con estado 404 Not Found
-                // en JSON.
+                // Si no existe devuelve un ResponseEntity con estado 404 Not Found en JSON.
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
 }

--- a/auth/src/main/java/com/cryfirock/auth/entity/Role.java
+++ b/auth/src/main/java/com/cryfirock/auth/entity/Role.java
@@ -25,8 +25,7 @@ import jakarta.validation.constraints.Size;
 @Entity @Table(name = "roles")
 public class Role {
     // 1. @Id: Clave primaria de la entidad.
-    // 2. @GeneratedValue(strategy = GenerationType.IDENTITY): Generación automática de clave
-    // primaria.
+    // 2. @GeneratedValue(strategy = GenerationType.IDENTITY): Genera la clave primaria.
     // 3. @Column(name = "id"): Columna de la tabla que almacena el ID del rol.
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -44,7 +43,7 @@ public class Role {
      * 3. Relación bidireccional para poder desde Roles obtener los Users que tienen un rol.
      * 4. Desde Role puedes acceder a sus users con role.getUsers().
      * {@code
-     *      User u = userRepository.findById(id).orElseThrow(() -> new RuntimeException("User not exists!"));
+     *      User u = userRepository.findById(id).orElseThrow(RuntimeException::new);
      *      Consultar a la base de datos:
      *      List<Role> roles = u.getRoles().size();
      *      Consultar a la memoria:

--- a/auth/src/main/java/com/cryfirock/auth/entity/User.java
+++ b/auth/src/main/java/com/cryfirock/auth/entity/User.java
@@ -161,17 +161,13 @@ public class User {
     private Audit audit;
 
     // 1. @Transient: No se mapea a ninguna columna de la tabla.
-    // 2. @JsonProperty(access = JsonProperty.Access.WRITE_ONLY):
-    // - Solo se puede deserializar y no se serializar en el JSON.
-    // - Solo se puede escribir y no se puede leer/devolver desde JSON.
+    // 2. @JsonProperty(WRITE_ONLY): Solo permite escritura vía JSON.
     // 3. Indica si el usuario tiene rol de administrador.
     @Transient @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     private boolean admin;
 
     // 1. @Transient: No se mapea a ninguna columna de la tabla.
-    // 2. @JsonProperty(access = JsonProperty.Access.WRITE_ONLY):
-    // - Solo se puede deserializar y no se serializar en el JSON.
-    // - Solo se puede escribir y no se puede leer/devolver desde JSON.
+    // 2. @JsonProperty(WRITE_ONLY): Solo permite escritura vía JSON.
     // 3. Puerto del servicio de autenticación.
     @Transient @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     private int port;

--- a/auth/src/main/java/com/cryfirock/auth/service/impl/UserServiceImpl.java
+++ b/auth/src/main/java/com/cryfirock/auth/service/impl/UserServiceImpl.java
@@ -102,9 +102,8 @@ public class UserServiceImpl implements IUserService {
                 .stream()
                 // 1. Mira cada usuario del stream.
                 // 2. Realiza una acción por cada usuario.
-                // 3. No transforma el Stream:
-                // - No se modifica el tipo de los elementos a retornar.
-                // - No se modifica la referencia de los elementos a retornar.
+                // 3. No transforma el Stream; no se modifica el tipo de los elementos a retornar.
+                // 4. No se modifica la referencia de los elementos a retornar.
                 .peek(user ->
                 // Establece el puerto del servidor en el usuario.
                 user.setPort(
@@ -221,8 +220,7 @@ public class UserServiceImpl implements IUserService {
                             // Actualiza el usuario con los datos del DTO.
                             userMapper.update(u, userDto);
 
-                            // Si el DTO contiene una contraseña la codifica y la establece en el
-                            // usuario.
+                            // Si el DTO trae contraseña, la codifica y la asigna al usuario.
                             if (userDto.passwordHash() != null && !userDto.passwordHash().isBlank())
                                 // Establece la contraseña del usuario.
                                 u.setPasswordHash(

--- a/auth/src/main/java/com/cryfirock/auth/util/ValidationUtil.java
+++ b/auth/src/main/java/com/cryfirock/auth/util/ValidationUtil.java
@@ -1,5 +1,6 @@
 package com.cryfirock.auth.util;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -78,7 +79,9 @@ public class ValidationUtil {
                         .stream()
                         .collect(Collectors.toMap(
                                 FieldError::getField,
-                                FieldError::getDefaultMessage,
+                                fieldError -> Objects.requireNonNullElse(
+                                        fieldError.getDefaultMessage(),
+                                        "Mensaje de validación no disponible."),
                                 (msg1, msg2) -> msg1 + "; " + msg2)));
     }
 }

--- a/product/src/main/java/com/cryfirock/product/util/ValidationUtil.java
+++ b/product/src/main/java/com/cryfirock/product/util/ValidationUtil.java
@@ -1,5 +1,6 @@
 package com.cryfirock.product.util;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -78,7 +79,9 @@ public class ValidationUtil {
                         .stream()
                         .collect(Collectors.toMap(
                                 FieldError::getField,
-                                FieldError::getDefaultMessage,
+                                fieldError -> Objects.requireNonNullElse(
+                                        fieldError.getDefaultMessage(),
+                                        "Mensaje de validación no disponible."),
                                 (msg1, msg2) -> msg1 + "; " + msg2)));
     }
 }


### PR DESCRIPTION
### Motivation

- Homogeneizar comentarios largos en una sola línea para cumplir las reglas de estilo del proyecto. 
- Evitar posibles mensajes nulos al construir el mapa de errores de validación y prevenir avisos/NPEs con un fallback. 
- Actualizar la documentación para dejar constancia del comportamiento de los mensajes de validación.

### Description

- Refactoricé comentarios multilínea/inline a comentarios de una sola línea en varias clases, incluyendo `auth` y `account` (`UserController`, `UserServiceImpl`, `User`, `Role`, `AccountUser`, etc.).
- Hice las utilidades de validación null-safe reemplazando `FieldError::getDefaultMessage` por `Objects.requireNonNullElse(fieldError.getDefaultMessage(), "Mensaje de validación no disponible.")` en `auth/src/main/java/com/cryfirock/auth/util/ValidationUtil.java` y `product/src/main/java/com/cryfirock/product/util/ValidationUtil.java`, y añadí la importación de `java.util.Objects`.
- Pequeños ajustes de redacción y claridad en comentarios y en una excepción de ejemplo (reemplazo de lambda por `RuntimeException::new`) en `auth/src/main/java/com/cryfirock/auth/entity/Role.java`.
- Actualicé la documentación en `README.md` y `AGENTS.md` para indicar la recomendación de usar un fallback no nulo al obtener mensajes de `FieldError`.

### Testing

- No se ejecutaron tests automatizados durante este cambio (ninguna prueba fue solicitada o invocada).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69765d7e39408327bbe6d17c90946083)